### PR TITLE
Purge leader cache

### DIFF
--- a/connector_test.go
+++ b/connector_test.go
@@ -140,6 +140,7 @@ func testProduce(t *testing.T, topicName string, numMessages int, connector *Def
 
 func testConsume(t *testing.T, topicName string, numMessages int, connector *DefaultConnector) {
 	response, err := connector.Fetch(topicName, 0, 0)
+	assertFatal(t, response.Error(topicName, 0), ErrNoError)
 	assertFatal(t, err, nil)
 	messages, err := response.GetMessages()
 	assertFatal(t, err, nil)

--- a/fetch.go
+++ b/fetch.go
@@ -123,6 +123,19 @@ func (fr *FetchResponse) GetMessages() ([]*MessageAndMetadata, error) {
 	return messages, err
 }
 
+// Error returns the error message for a given topic and pertion of this FetchResponse
+func (fr *FetchResponse) Error(topic string, partition int32) error {
+	t, ok := fr.Data[topic]
+	if !ok {
+		return nil
+	}
+	p, ok := t[partition]
+	if !ok {
+		return nil
+	}
+	return p.Error
+}
+
 // CollectMessages traverses this FetchResponse and applies a collector function to each message
 // giving the possibility to avoid response -> siesta.Message -> other.Message conversion if necessary.
 func (fr *FetchResponse) CollectMessages(collector func(topic string, partition int32, offset int64, key []byte, value []byte)) error {


### PR DESCRIPTION
Hi,

I encountered an issue that go_kafka_client sometimes keeps outputting messages like below forever, when I shutdown one of the brokers of a 3-node cluster. 

```
2016-02-02/01:54:12 [WARN] [ConsumerFetcherRoutine-0548e355-d927-bf25-a18f-57b6142b5e9f-0] Got a metadata out of fetch error for topic <topic_name>, partition 0: You've just attempted to send messages to a replica that is not the leader for some partition. It indicates that the clients metadata is out of date.
```

I'm not sure if this error should be handled by go_kafka_client (by recreating fetchers who raised this error?), but anyway, tried writing a patch that refleshes cached leaders when the connector got an `ErrNotLeaderForPartition` error.

If this solution makes sense, I'll write some tests and update the PR.