### PR TITLE
Stop brokers in which connector is interested

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -452,6 +452,19 @@ func (dc *DefaultConnector) refreshLeaders(response *MetadataResponse) {
 			}
 		}
 	}
+
+	for _, broker := range brokers {
+		found := false
+		for _, link := range dc.links {
+			if broker == link {
+				found = true
+				break
+			}
+		}
+		if !found {
+			broker.stop <- true
+		}
+	}
 }
 
 func (dc *DefaultConnector) getMetadata(topics []string) (*MetadataResponse, error) {


### PR DESCRIPTION
Hi,

I found that every time I stop a broker which is the leader of a partition which is streaming to a client build with this library, number of gouroutines  is increasing in the process. This patch makes the connector stop unnecessary broker links when it refreshes metadata.